### PR TITLE
SendMessage(string, color) should invoke SendMessage(string, byte, byte,...

### DIFF
--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -924,7 +924,7 @@ namespace TShockAPI
 
 		public override void SendMessage(string msg, Color color)
 		{
-			SendInfoMessage(msg, color.R, color.G, color.B);
+			SendMessage(msg, color.R, color.G, color.B);
 		}
 
 		public override void SendMessage(string msg, byte red, byte green, byte blue)


### PR DESCRIPTION
... byte), not SendInfoMessage(string, obj[]) resulting in a infinite loop.  Fixes #873